### PR TITLE
set doc 115 status to draft

### DIFF
--- a/sources/115/document.adoc
+++ b/sources/115/document.adoc
@@ -6,7 +6,7 @@
 :language: en
 :title-main-en: Internationalized semantic punctuation framework
 :doctype: standard
-:status: published
+:status: draft
 :mn-document-class: ribose
 :mn-output-extensions: xml,html,pdf,rxl
 :local-cache-only:


### PR DESCRIPTION
Set doc 115 (Internationalized semantic punctuation framework) status to `draft`.

It was published live showing as **PUBLISHED** in the docs listing, but it should be **DRAFT** like doc 113. The status is driven by the `:status:` AsciiDoc attribute in `sources/115/document.adoc`, which flows into the generated `.rxl` stage and the metanorma.github.io/docs/ listing. Changed `:status: published` → `:status: draft`.

Merging to main retriggers the `generate` workflow, which rebuilds the `.rxl` as `draft` and redeploys the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
